### PR TITLE
IT-630_puppet reporting to dd

### DIFF
--- a/files/puppet_last_run.py
+++ b/files/puppet_last_run.py
@@ -1,0 +1,17 @@
+from checks import AgentCheck
+from time import time
+import yaml         #requires PyYAML
+
+class puppetCheck(AgentCheck):
+  def check(self, instance):
+    with open("/var/lib/puppet/state/last_run_summary.yaml", "r") as summary:
+        file_data = yaml.load(summary)
+        date = file_data["time"]["last_run"]
+        failures = file_data["events"]["failure"]
+        age_seconds = time() - date
+
+        version = file_data["version"]["puppet"]
+        tag = "puppet_version:" + version
+
+        self.gauge("puppet.last_run_age_seconds",age_seconds,tags=[tag])
+        self.gauge("puppet.last_run_num_failures",failures,tags=[tag])

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -117,7 +117,12 @@ class datadog_agent(
     mode    => '0755',
     require => Package['datadog-agent'],
   }
-    
+
+  file {['/etc/dd-agent/conf.d/', '/etc/dd-agent/checks.d/']:
+  ensure => directory,
+  owner  => 'dd-agent'
+  }
+
   #for puppet run success reporting to datadog.
   include datadog_agent::puppet_last_run
 
@@ -138,5 +143,4 @@ class datadog_agent(
       puppetmaster_user => $puppetmaster_user,
     }
   }
-
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -117,6 +117,9 @@ class datadog_agent(
     mode    => '0755',
     require => Package['datadog-agent'],
   }
+    
+  #for puppet run success reporting to datadog.
+  include datadog_agent::puppet_last_run
 
   # main agent config file
   file { '/etc/dd-agent/datadog.conf':

--- a/manifests/puppet_last_run.pp
+++ b/manifests/puppet_last_run.pp
@@ -1,13 +1,4 @@
 class datadog_agent::puppet_last_run {
-  file {'/etc/dd-agent/conf.d/':
-    ensure => directory,
-    owner  => 'dd-agent'
-    } ->
-  file {'/etc/dd-agent/checks.d/':
-    ensure => directory,
-    owner  => 'dd-agent',
-    } ->
-
   file { '/etc/dd-agent/checks.d/puppet_last_run.py':
     ensure  => file,
     owner  => 'dd-agent',

--- a/manifests/puppet_last_run.pp
+++ b/manifests/puppet_last_run.pp
@@ -1,0 +1,23 @@
+class datadog_agent::puppet_last_run {
+  file {'/etc/dd-agent/conf.d/':
+    ensure => directory,
+    owner  => 'dd-agent'
+    } ->
+  file {'/etc/dd-agent/checks.d/':
+    ensure => directory,
+    owner  => 'dd-agent',
+    } ->
+
+  file { '/etc/dd-agent/checks.d/puppet_last_run.py':
+    ensure  => file,
+    owner  => 'dd-agent',
+    source  => 'puppet:///modules/datadog_agent/puppet_last_run.py',
+    notify  => Service['datadog-agent'],
+  } ->
+  file { '/etc/dd-agent/conf.d/puppet_last_run.yaml':
+    ensure  => file,
+    content => template('datadog_agent/puppet_last_run.yaml.erb'),
+    owner   => 'dd-agent',
+    notify  => Service['datadog-agent'],
+  }
+}

--- a/templates/puppet_last_run.yaml.erb
+++ b/templates/puppet_last_run.yaml.erb
@@ -1,0 +1,4 @@
+init_config:
+
+instances:
+  - name: puppet_last_run_metric


### PR DESCRIPTION
ok, did a little testing. seems to work on the monitoring host, which uses datadog. 
It doesn't halt the local puppet run on ip-10-102-254-190.qa.us-west-2.pwr, the qa-pufferfish-worker-generic.

